### PR TITLE
Implement secure refresh token flow

### DIFF
--- a/next-api/prisma/schema.prisma
+++ b/next-api/prisma/schema.prisma
@@ -576,6 +576,19 @@ model User {
 
   quotationtable quotationtable[] @relation("UserQuotationAdmin")
   invoicetable   invoicetable[]   @relation("UserInvoiceAdmin")
+  refreshTokens  RefreshToken[]
+}
+
+model RefreshToken {
+  id          Int      @id @default(autoincrement())
+  hashedToken String   @unique @db.Char(64)
+  userId      Int
+  user        User     @relation(fields: [userId], references: [IDUser], onDelete: Cascade)
+  expiresAt   DateTime
+  revokedAt   DateTime?
+  createdAt   DateTime @default(now())
+
+  @@index([userId])
 }
 
 model warranty_services {

--- a/next-api/src/app/api/auth/login/route.js
+++ b/next-api/src/app/api/auth/login/route.js
@@ -1,10 +1,12 @@
 import { NextResponse } from "next/server";
 import prisma from "../../../../../prisma/client";
-import jwt from "jsonwebtoken";
 import bcrypt from "bcryptjs";
 import { z } from "zod";
-
-const JWT_SECRET = process.env.JWT_SECRET || "";
+import {
+    applyRefreshCookie,
+    createAccessToken,
+    generateRefreshToken
+} from "@/utils/auth";
 
 const loginSchema = z.object({
     identifier: z
@@ -73,25 +75,21 @@ export async function POST(request) {
             return NextResponse.json({ success: false, message: "Incorrect password" }, { status: 401 });
         }
 
-        const token = jwt.sign(
-            {
-                id: user.IDUser,
-                email: user.Email,
-                role: user.Role,
-                name: user.Name,
-                avatar: user.ProfilePhoto || ""
-            },
-            JWT_SECRET,
-            { expiresIn: "7d" }
-        );
+        const { token, expiresAt } = createAccessToken(user);
+        const { token: refreshToken, hashedToken, expiresAt: refreshExpiresAt } = generateRefreshToken();
 
-        const decodedToken = jwt.decode(token);
-        const expiresAt = decodedToken?.exp ? decodedToken.exp * 1000 : null;
+        await prisma.refreshToken.create({
+            data: {
+                userId: user.IDUser,
+                hashedToken,
+                expiresAt: refreshExpiresAt
+            }
+        });
 
-        return NextResponse.json({
+        const response = NextResponse.json({
             success: true,
             message: "Login successful",
-            token,
+            accessToken: token,
             expiresAt,
             data: {
                 id: user.IDUser,
@@ -101,6 +99,10 @@ export async function POST(request) {
                 profile: user.ProfilePhoto
             }
         });
+
+        applyRefreshCookie(response, refreshToken);
+
+        return response;
     } catch (error) {
         console.error("🔥 Login Error:", error);
         return NextResponse.json({ success: false, message: "Internal server error" }, { status: 500 });

--- a/next-api/src/app/api/auth/logout/route.js
+++ b/next-api/src/app/api/auth/logout/route.js
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+import prisma from "../../../../../prisma/client";
+import { clearRefreshCookie, hashToken, REFRESH_COOKIE_NAME } from "@/utils/auth";
+
+export async function POST(request) {
+  const token = request.cookies.get(REFRESH_COOKIE_NAME)?.value;
+  const response = NextResponse.json({ success: true });
+
+  if (!token) {
+    clearRefreshCookie(response);
+    return response;
+  }
+
+  try {
+    await prisma.refreshToken.updateMany({
+      where: {
+        hashedToken: hashToken(token)
+      },
+      data: { revokedAt: new Date() }
+    });
+  } catch (error) {
+    console.error("Failed to revoke refresh token", error);
+  }
+
+  clearRefreshCookie(response);
+  return response;
+}

--- a/next-api/src/app/api/auth/refresh/route.js
+++ b/next-api/src/app/api/auth/refresh/route.js
@@ -1,0 +1,84 @@
+import { NextResponse } from "next/server";
+import prisma from "../../../../../prisma/client";
+import {
+  applyRefreshCookie,
+  clearRefreshCookie,
+  createAccessToken,
+  generateRefreshToken,
+  hashToken,
+  REFRESH_COOKIE_NAME
+} from "@/utils/auth";
+
+export async function POST(request) {
+  const existingToken = request.cookies.get(REFRESH_COOKIE_NAME)?.value;
+
+  if (!existingToken) {
+    return NextResponse.json(
+      { success: false, message: "Missing refresh token" },
+      { status: 401 }
+    );
+  }
+
+  try {
+    const hashed = hashToken(existingToken);
+
+    const storedToken = await prisma.refreshToken.findFirst({
+      where: {
+        hashedToken: hashed,
+        revokedAt: null,
+        expiresAt: { gt: new Date() }
+      },
+      include: { user: true }
+    });
+
+    if (!storedToken?.user) {
+      const response = NextResponse.json(
+        { success: false, message: "Refresh token is invalid" },
+        { status: 401 }
+      );
+      clearRefreshCookie(response);
+      return response;
+    }
+
+    await prisma.refreshToken.update({
+      where: { id: storedToken.id },
+      data: { revokedAt: new Date() }
+    });
+
+    const { token: newRefreshToken, hashedToken, expiresAt: refreshExpiresAt } = generateRefreshToken();
+    await prisma.refreshToken.create({
+      data: {
+        userId: storedToken.userId,
+        hashedToken,
+        expiresAt: refreshExpiresAt
+      }
+    });
+
+    const { token: accessToken, expiresAt } = createAccessToken(storedToken.user);
+
+    const response = NextResponse.json({
+      success: true,
+      accessToken,
+      expiresAt,
+      data: {
+        id: storedToken.user.IDUser,
+        name: storedToken.user.Name,
+        email: storedToken.user.Email,
+        role: storedToken.user.Role,
+        profile: storedToken.user.ProfilePhoto
+      }
+    });
+
+    applyRefreshCookie(response, newRefreshToken);
+
+    return response;
+  } catch (error) {
+    console.error("Failed to refresh session", error);
+    const response = NextResponse.json(
+      { success: false, message: "Unable to refresh session" },
+      { status: 401 }
+    );
+    clearRefreshCookie(response);
+    return response;
+  }
+}

--- a/next-api/src/app/api/user/[IDUser]/route.js
+++ b/next-api/src/app/api/user/[IDUser]/route.js
@@ -1,13 +1,10 @@
 import { NextResponse } from "next/server";
 import prisma from "../../../../../prisma/client";
-import jwt from 'jsonwebtoken';
 import bcrypt from "bcryptjs";
 import fs from "fs";
 import path from "path";
-import crypto from "crypto"; 
-
-
-const JWT_SECRET =  process.env.JWT_SECRET || '' 
+import crypto from "crypto";
+import { createAccessToken } from "@/utils/auth";
 
 // GET - Ambil detail user berdasarkan ID
 export async function GET(request, { params }) {
@@ -144,23 +141,13 @@ export async function PATCH(request, { params }) {
     });
 
     
-    const newToken = jwt.sign(
-      {
-        id: updatedUser.IDUser,
-        email: updatedUser.Email,
-        role: updatedUser.Role,
-        name: updatedUser.Name,
-        avatar: updatedUser.ProfilePhoto || "",
-      },
-      JWT_SECRET,
-      { expiresIn: "7d" }
-    );
-
+    const { token: accessToken, expiresAt } = createAccessToken(updatedUser);
 
     return NextResponse.json({
       success: true,
       message: "Data user berhasil diperbarui",
-      token: newToken,
+      accessToken,
+      expiresAt,
       data: updatedUser
     }, { status: 200 });
 

--- a/next-api/src/app/middleware/auth.js
+++ b/next-api/src/app/middleware/auth.js
@@ -1,16 +1,24 @@
-import { headers } from "next/headers";
-import jwt from 'jsonwebtoken'
-
-const JWT_SECRET = process.env.JWT_SECRET || ''
+import { verifyAccessToken } from "@/utils/auth";
 
 export function getTokenUserId(request) {
   try {
+    const forwardedUserId = request.headers.get('x-user-id');
+    if (forwardedUserId) {
+      const parsed = parseInt(forwardedUserId, 10);
+      return Number.isNaN(parsed) ? forwardedUserId : parsed;
+    }
+
     const authHeader = request.headers.get('authorization');
     const token = authHeader?.replace('Bearer ', '');
     if (!token) return null;
 
-    const decoded = jwt.verify(token, JWT_SECRET);
-    return decoded.id || null;
+    const verification = verifyAccessToken(token);
+    if (!verification.valid) {
+      return null;
+    }
+
+    const payload = verification.payload;
+    return payload?.sub ?? payload?.id ?? null;
   } catch {
     return null;
   }

--- a/next-api/src/middleware.js
+++ b/next-api/src/middleware.js
@@ -1,0 +1,48 @@
+import { NextResponse } from "next/server";
+import { verifyAccessToken } from "@/utils/auth";
+
+const AUTH_WHITELIST = [
+  "/api/auth/login",
+  "/api/auth/refresh",
+  "/api/auth/logout"
+];
+
+export function middleware(request) {
+  const { pathname } = request.nextUrl;
+
+  if (!pathname.startsWith("/api")) {
+    return NextResponse.next();
+  }
+
+  if (AUTH_WHITELIST.some((path) => pathname.startsWith(path))) {
+    return NextResponse.next();
+  }
+
+  const authHeader = request.headers.get("authorization");
+
+  if (!authHeader?.startsWith("Bearer ")) {
+    return NextResponse.json({ success: false, message: "Unauthorized" }, { status: 401 });
+  }
+
+  const token = authHeader.slice(7).trim();
+  const verification = verifyAccessToken(token);
+
+  if (!verification.valid) {
+    return NextResponse.json({ success: false, message: "Unauthorized" }, { status: 401 });
+  }
+
+  const headers = new Headers(request.headers);
+  headers.set("x-user-id", String(verification.payload?.sub ?? ""));
+  headers.set("x-user-role", verification.payload?.role ?? "");
+  headers.set("x-user-email", verification.payload?.email ?? "");
+
+  return NextResponse.next({
+    request: {
+      headers
+    }
+  });
+}
+
+export const config = {
+  matcher: "/api/:path*"
+};

--- a/next-api/src/utils/auth.js
+++ b/next-api/src/utils/auth.js
@@ -1,0 +1,75 @@
+import crypto from "crypto";
+import jwt from "jsonwebtoken";
+
+const JWT_SECRET = process.env.JWT_SECRET || "dev-secret";
+const JWT_ISSUER = process.env.JWT_ISSUER || "tes-app";
+const JWT_AUDIENCE = process.env.JWT_AUDIENCE || "tes-app-users";
+const ACCESS_TOKEN_TTL = process.env.JWT_ACCESS_TOKEN_TTL || "15m";
+const REFRESH_TOKEN_TTL_DAYS = parseInt(process.env.JWT_REFRESH_TOKEN_TTL_DAYS || "14", 10);
+export const REFRESH_TOKEN_TTL_MS = REFRESH_TOKEN_TTL_DAYS * 24 * 60 * 60 * 1000;
+export const REFRESH_COOKIE_NAME = "refresh_token";
+
+export function createAccessToken(user) {
+  const payload = {
+    sub: user.IDUser,
+    id: user.IDUser,
+    email: user.Email,
+    role: user.Role,
+    name: user.Name,
+    avatar: user.ProfilePhoto || "",
+    iss: JWT_ISSUER,
+    aud: JWT_AUDIENCE,
+    jti: crypto.randomUUID()
+  };
+
+  const token = jwt.sign(payload, JWT_SECRET, {
+    expiresIn: ACCESS_TOKEN_TTL,
+    issuer: JWT_ISSUER,
+    audience: JWT_AUDIENCE
+  });
+
+  const decoded = jwt.decode(token);
+  const expiresAt = decoded?.exp ? decoded.exp * 1000 : null;
+
+  return { token, expiresAt };
+}
+
+export function verifyAccessToken(token) {
+  try {
+    const payload = jwt.verify(token, JWT_SECRET, {
+      issuer: JWT_ISSUER,
+      audience: JWT_AUDIENCE
+    });
+
+    return { valid: true, payload };
+  } catch (error) {
+    return { valid: false, error };
+  }
+}
+
+export function hashToken(token) {
+  return crypto.createHash("sha256").update(token).digest("hex");
+}
+
+export function generateRefreshToken() {
+  const token = crypto.randomBytes(64).toString("hex");
+  const hashedToken = hashToken(token);
+  const expiresAt = new Date(Date.now() + REFRESH_TOKEN_TTL_MS);
+  return { token, hashedToken, expiresAt };
+}
+
+export function applyRefreshCookie(response, value, { maxAge = REFRESH_TOKEN_TTL_MS / 1000 } = {}) {
+  response.cookies.set(REFRESH_COOKIE_NAME, value, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "strict",
+    path: "/api/auth",
+    maxAge
+  });
+
+  return response;
+}
+
+export function clearRefreshCookie(response) {
+  return applyRefreshCookie(response, "", { maxAge: 0 });
+}

--- a/test-vite/src/Home.jsx
+++ b/test-vite/src/Home.jsx
@@ -3,10 +3,12 @@ import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle }
 import { Button } from './components/ui/button';
 import { FindCase } from './components/model/sc-modal'; // Assuming this is a modal trigger
 import { useNavigate } from 'react-router-dom'; // Corrected import for useNavigate
+import { useAuth } from '@/context/auth-context';
 
 export const Home = () => {
     const navigate = useNavigate();
-    const token = localStorage.getItem('token');
+    const { user, loading } = useAuth();
+    const isLoggedIn = Boolean(user);
 
     return (
         <div className="relative min-h-screen bg-cover bg-center bg-no-repeat" style={{ backgroundImage: "url('/bg-1.jpg')" }}>
@@ -81,7 +83,14 @@ export const Home = () => {
                                 </CardDescription>
                             </CardContent>
                             <CardFooter>
-                                {token ? (
+                                {loading ? (
+                                    <Button
+                                        className="text-lg md:text-xl px-4 py-2 text-white bg-emerald-600 rounded-md shadow-md"
+                                        disabled
+                                    >
+                                        Checking session...
+                                    </Button>
+                                ) : isLoggedIn ? (
                                     <Button
                                         className="text-lg md:text-xl px-4 py-2 text-white bg-emerald-600 hover:bg-emerald-700 rounded-md shadow-md transition-colors duration-200"
                                         onClick={() => navigate('/app')}

--- a/test-vite/src/api/index.jsx
+++ b/test-vite/src/api/index.jsx
@@ -1,7 +1,71 @@
 import axios from "axios";
+import { clearToken, getToken, setToken } from "@/lib/utils/auth";
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
 const ApiCustomer = axios.create({
-    baseURL: import.meta.env.VITE_API_BASE_URL
-})
+    baseURL: API_BASE_URL,
+    withCredentials: true
+});
+
+ApiCustomer.interceptors.request.use((config) => {
+    const token = getToken();
+    if (token) {
+        config.headers = config.headers ?? {};
+        config.headers.Authorization = `Bearer ${token}`;
+    }
+    return config;
+});
+
+let refreshPromise = null;
+
+async function requestNewAccessToken() {
+    if (!refreshPromise) {
+        refreshPromise = axios.post(`${API_BASE_URL}/api/auth/refresh`, {}, { withCredentials: true });
+    }
+
+    try {
+        return await refreshPromise;
+    } finally {
+        refreshPromise = null;
+    }
+}
+
+ApiCustomer.interceptors.response.use(
+    (response) => response,
+    async (error) => {
+        const originalRequest = error.config || {};
+        const status = error.response?.status;
+        const shouldRetry =
+            status === 401 &&
+            !originalRequest._retry &&
+            !originalRequest.url?.includes("/api/auth/login") &&
+            !originalRequest.url?.includes("/api/auth/refresh");
+
+        if (!shouldRetry) {
+            return Promise.reject(error);
+        }
+
+        originalRequest._retry = true;
+
+        try {
+            const refreshResponse = await requestNewAccessToken();
+            const newToken = refreshResponse.data?.accessToken;
+
+            if (!newToken) {
+                throw new Error("Refresh endpoint did not return an access token");
+            }
+
+            setToken(newToken);
+            originalRequest.headers = originalRequest.headers ?? {};
+            originalRequest.headers.Authorization = `Bearer ${newToken}`;
+
+            return ApiCustomer(originalRequest);
+        } catch (refreshError) {
+            clearToken();
+            return Promise.reject(refreshError);
+        }
+    }
+);
 
 export default ApiCustomer;

--- a/test-vite/src/components/GateKeepingRouting.jsx
+++ b/test-vite/src/components/GateKeepingRouting.jsx
@@ -1,11 +1,15 @@
-import { Navigate, Outlet } from "react-router";
-
+import { Navigate } from "react-router";
 import App from "@/App";
+import { useAuth } from "@/context/auth-context";
 
 export const GateKeepingRouting = () => {
-    const token = localStorage.getItem('token');
+    const { user, loading } = useAuth();
 
-    if(!token) {
+    if (loading) {
+        return null;
+    }
+
+    if(!user) {
         return <Navigate to="/lorem" replace />
     }
 

--- a/test-vite/src/components/MasterGateKeeping.jsx
+++ b/test-vite/src/components/MasterGateKeeping.jsx
@@ -1,8 +1,12 @@
 import { Navigate } from "react-router";
-import { getUserFromToken } from "@/lib/utils/auth";
+import { useAuth } from "@/context/auth-context";
 
 export const MasterGateKeeping = ( { children, allow }) => {
-    const user = getUserFromToken();
+    const { user, loading } = useAuth();
+
+    if (loading) {
+        return null;
+    }
     // if(!user || user.role !== 'admin'){
     //     /**
     //      * TODO

--- a/test-vite/src/components/audit-windows.jsx
+++ b/test-vite/src/components/audit-windows.jsx
@@ -2,11 +2,16 @@ import React from 'react'
 import { Card, CardContent, CardHeader, CardTitle } from './ui/card'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from './ui/table'
 import { Navigate } from 'react-router'
+import { useAuth } from '@/context/auth-context'
 
 export const Auditwindows = () => {
-      const token = localStorage.getItem('token');
-  
-      if(!token) {
+      const { user, loading } = useAuth();
+
+      if (loading) {
+          return null;
+      }
+
+      if(!user) {
           return <Navigate to="/lorem" replace />
       }
   return (

--- a/test-vite/src/components/login-form.jsx
+++ b/test-vite/src/components/login-form.jsx
@@ -30,8 +30,11 @@ export function LoginForm({ className, ...props }) {
         password,
       });
       console.log("Login success:", res.data);
-      const { token } = res.data;
-      login(token);
+      const { accessToken } = res.data;
+      if (!accessToken) {
+        throw new Error("Missing access token in response");
+      }
+      login(accessToken);
 
       Swal.fire({
         title: "Success",

--- a/test-vite/src/components/model/sc-modal.jsx
+++ b/test-vite/src/components/model/sc-modal.jsx
@@ -77,7 +77,6 @@ import {
   PaginationPrevious,
 } from "@/components/ui/pagination"
 
-import { getUserFromToken } from "@/lib/utils/auth";
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
 import ServiceRequestPDF from "../service-request-form";
 import { pdf } from '@react-pdf/renderer';
@@ -5156,8 +5155,14 @@ console.log("Asset Info OTC : ",isOutWarranty)
           allowEscapeKey: false,
           didOpen: () => Swal.showLoading()
         });
+        if (!user) {
+          Swal.close();
+          toast.error("User session expired. Please login again.");
+          return;
+        }
+
         const data = {
-          user: getUserFromToken()
+          user
         }
 
 
@@ -7947,7 +7952,11 @@ export function BookingDetailsAdd({ onUpdate }) {
   };
   
   const handleSubmit = async () => {
-    const userSubmit = getUserFromToken();
+    const userSubmit = user;
+    if (!userSubmit) {
+      toast.error("User session expired. Please login again.");
+      return;
+    }
     try {
       const payload = {
         ...formData,
@@ -8186,7 +8195,11 @@ export function BookingDetailsEdit({ BookingDetailId, onUpdate }) {
 
   // Submit edited data
   const handleSubmit = async () => {
-    const userSubmit = getUserFromToken();
+    const userSubmit = user;
+    if (!userSubmit) {
+      toast.error("User session expired. Please login again.");
+      return;
+    }
 
     try {
       const payload = {

--- a/test-vite/src/components/sidebar/app-sidebar.jsx
+++ b/test-vite/src/components/sidebar/app-sidebar.jsx
@@ -27,7 +27,7 @@ import {
   SidebarRail,
 } from "@/components/ui/sidebar"
 
-import { getUserFromToken } from "@/lib/utils/auth"
+import { useAuth } from "@/context/auth-context";
 import { Separator } from "../ui/separator"
 import { Hpicon, Javagicon } from "../icon";
 import { useDraft } from "../DraftContext";
@@ -39,8 +39,9 @@ export function AppSidebar({
   ...props
 }) {
   const { drafts } = useDraft();
+  const { user } = useAuth();
   if (!drafts) {
-    return null; 
+    return null;
   }
   const data = {
     // user: {
@@ -48,7 +49,7 @@ export function AppSidebar({
     //   email: "m@example.com",
     //   avatar: "/avatars/shadcn.jpg",
     // },
-    user: getUserFromToken(),
+    user: user ?? { name: "", email: "", avatar: "" },
     teams: [
       {
         name: "PT Javag",

--- a/test-vite/src/components/sidebar/nav-user.jsx
+++ b/test-vite/src/components/sidebar/nav-user.jsx
@@ -32,11 +32,13 @@ import {
 
 import Swal from "sweetalert2"
 import { useSheet } from "@/context/sheet-context"
+import { useAuth } from "@/context/auth-context";
 
 export function NavUser({
   user
 }) {
   const navigate = useNavigate();
+  const { logout: signOut } = useAuth();
 
   const goToProfile = () => {
     navigate("/app/profiles");
@@ -46,18 +48,17 @@ export function NavUser({
 
   const API_BASE = import.meta.env.VITE_API_BASE_URL || "http://localhost:3000";
 
-  const logout = () => {
-    localStorage.removeItem('token');
-  
+  const handleLogout = async () => {
+    await signOut();
     Swal.fire({
       title: "Success",
       text: "User has been logged out",
       icon: "success",
       allowOutsideClick: false,
-      timer: 1500, 
+      timer: 1500,
       showConfirmButton: false
     }).then(() => {
-      window.location.href = '/lorem'; 
+      window.location.href = '/lorem';
     });
   };
   
@@ -117,7 +118,7 @@ export function NavUser({
               </DropdownMenuItem>
             </DropdownMenuGroup>
             <DropdownMenuSeparator />
-            <DropdownMenuItem onClick={logout} className={"cursor-pointer bg-red-300 "}>
+            <DropdownMenuItem onClick={handleLogout} className={"cursor-pointer bg-red-300 "}>
             <span  className="flex items-center gap-2">
               <LogOut className="w-5 h-5" />
               <span>Log out</span>

--- a/test-vite/src/components/tests/service.jsx
+++ b/test-vite/src/components/tests/service.jsx
@@ -47,13 +47,16 @@ import ApiCustomer from "@/api";
 
 import { CaseField, QuickWOInput } from "../quick-wo-input";
 import { NewBookableResourceBooking } from "../service-booking";
-import { getUserFromToken } from "@/lib/utils/auth";
+import { useAuth } from "@/context/auth-context";
 
 import { useNavigate } from "react-router";
 import DatePicker from "../date-picker";
 
 export const ServiceWork = () => {
-  const user = getUserFromToken();
+  const { user } = useAuth();
+  if (!user) {
+    return null;
+  }
   const { woid } = useParams();
 
   const [workOrders, setWorkOrders] = useState([]);

--- a/test-vite/src/components/user-profile.jsx
+++ b/test-vite/src/components/user-profile.jsx
@@ -17,7 +17,7 @@ import { usePalette, useColor } from 'color-thief-react';
 
 
 export function UserProfile() {
-    const {user} = useAuth();
+    const {user, login, refreshSession} = useAuth();
     const [dominantColor, setDominantColor] = useState([0, 200, 255]); const imgRef = useRef(null);
     
 
@@ -31,7 +31,7 @@ export function UserProfile() {
         NewPassword: "",
         ProfilePhoto: null,
         Signature: null,
-        Role: user.role
+        Role: user?.role ?? ""
     })
     const [preview, setPreview] = useState({
         ProfilePhoto: null,
@@ -139,7 +139,11 @@ export function UserProfile() {
                 },
             })
             if (res.data.data) {
-                localStorage.setItem("token", res.data.token);
+                if (res.data.accessToken) {
+                    login(res.data.accessToken);
+                } else {
+                    await refreshSession().catch(() => null);
+                }
                 setIsDialogEditOpen(false);
 
                 toast("data berhasil diupdate");
@@ -211,9 +215,9 @@ export function UserProfile() {
                     )}
                     <Badge
                         variant="outline"
-                        className={user.role == 'admin' ? 'bg-amber-200' : 'bg-gray-200'}
+                        className={user?.role == 'admin' ? 'bg-amber-200' : 'bg-gray-200'}
                     >
-                        Role: {user.role}
+                        Role: {user?.role ?? 'user'}
                     </Badge>
 
             <Dialog open={isDialogEditOpen} onOpenChange={setIsDialogEditOpen}>

--- a/test-vite/src/context/auth-context.jsx
+++ b/test-vite/src/context/auth-context.jsx
@@ -1,67 +1,101 @@
 import { createContext, useContext, useEffect, useState, useRef, useCallback } from "react";
-import { getUserFromToken, setToken, clearToken, getToken } from "@/lib/utils/auth";
+import ApiCustomer from "@/api";
+import { getUserFromToken, setToken, clearToken } from "@/lib/utils/auth";
 
 const AuthContext = createContext(null);
 
 export function AuthProvider({ children }) {
     const [user, setUser] = useState(null);
     const [loading, setLoading] = useState(true);
-    const logoutTimerRef = useRef(null);
+    const refreshTimerRef = useRef(null);
+    const refreshAccessTokenRef = useRef(null);
 
-    const clearLogoutTimer = useCallback(() => {
-        if (logoutTimerRef.current) {
-            clearTimeout(logoutTimerRef.current);
-            logoutTimerRef.current = null;
+    const clearRefreshTimer = useCallback(() => {
+        if (refreshTimerRef.current) {
+            clearTimeout(refreshTimerRef.current);
+            refreshTimerRef.current = null;
         }
     }, []);
 
-    const logout = useCallback(() => {
-        clearLogoutTimer();
-        clearToken();
-        setUser(null);
-    }, [clearLogoutTimer]);
-
-    const scheduleLogout = useCallback((tokenPayload) => {
-        clearLogoutTimer();
-
-        if (!tokenPayload?.exp) {
-            return;
+    const applySession = useCallback((token) => {
+        clearRefreshTimer();
+        if (!token) {
+            clearToken();
+            setUser(null);
+            return null;
         }
 
-        const expiresInMs = tokenPayload.exp * 1000 - Date.now();
-
-        if (expiresInMs <= 0) {
-            logout();
-            return;
-        }
-
-        logoutTimerRef.current = setTimeout(() => {
-            logout();
-        }, expiresInMs);
-    }, [logout, clearLogoutTimer]);
-
-    const login = useCallback((token) => {
         setToken(token);
-        const userData = getUserFromToken(token);
-        setUser(userData);
-        scheduleLogout(userData);
-    }, [scheduleLogout]);
+        const nextUser = getUserFromToken(token);
+        setUser(nextUser);
+        return nextUser;
+    }, [clearRefreshTimer]);
+
+    const scheduleRefresh = useCallback((payload) => {
+        clearRefreshTimer();
+        if (!payload?.exp) {
+            return;
+        }
+
+        const msUntilExpiry = payload.exp * 1000 - Date.now();
+        const refreshIn = Math.max(msUntilExpiry - 30_000, 0);
+
+        refreshTimerRef.current = setTimeout(() => {
+            refreshAccessTokenRef.current?.().catch(() => {
+                applySession(null);
+            });
+        }, refreshIn);
+    }, [applySession, clearRefreshTimer]);
+
+    const refreshAccessToken = useCallback(async () => {
+        try {
+            const { data } = await ApiCustomer.post("/api/auth/refresh");
+            if (!data?.accessToken) {
+                throw new Error("Missing access token in refresh response");
+            }
+
+            const payload = applySession(data.accessToken);
+            scheduleRefresh(payload);
+            return payload;
+        } catch (error) {
+            applySession(null);
+            throw error;
+        }
+    }, [applySession, scheduleRefresh]);
 
     useEffect(() => {
-        const token = getToken();
-        const userData = token ? getUserFromToken(token) : null;
+        refreshAccessTokenRef.current = refreshAccessToken;
+    }, [refreshAccessToken]);
 
-        setUser(userData);
-        scheduleLogout(userData);
-        setLoading(false);
+    const login = useCallback((token) => {
+        const payload = applySession(token);
+        scheduleRefresh(payload);
+    }, [applySession, scheduleRefresh]);
+
+    const logout = useCallback(async () => {
+        clearRefreshTimer();
+        applySession(null);
+        try {
+            await ApiCustomer.post("/api/auth/logout");
+        } catch (error) {
+            console.error("Failed to logout", error);
+        }
+    }, [applySession, clearRefreshTimer]);
+
+    const refreshSession = useCallback(() => refreshAccessToken(), [refreshAccessToken]);
+
+    useEffect(() => {
+        refreshAccessToken()
+            .catch(() => null)
+            .finally(() => setLoading(false));
 
         return () => {
-            clearLogoutTimer();
+            clearRefreshTimer();
         };
-    }, [scheduleLogout, clearLogoutTimer]);
+    }, [refreshAccessToken, clearRefreshTimer]);
 
     return (
-        <AuthContext.Provider value={{ user, loading, login, logout }}>
+        <AuthContext.Provider value={{ user, loading, login, logout, refreshSession }}>
             {children}
         </AuthContext.Provider>
     );

--- a/test-vite/src/lib/utils/auth.js
+++ b/test-vite/src/lib/utils/auth.js
@@ -1,17 +1,17 @@
 import { jwtDecode } from "jwt-decode";
 
-const TOKEN_KEY = "token";
+let inMemoryToken = null;
 
 export function getToken() {
-  return localStorage.getItem(TOKEN_KEY);
+  return inMemoryToken;
 }
 
 export function setToken(token) {
-  localStorage.setItem(TOKEN_KEY, token);
+  inMemoryToken = token || null;
 }
 
 export function clearToken() {
-  localStorage.removeItem(TOKEN_KEY);
+  inMemoryToken = null;
 }
 
 export function isTokenExpired(decodedToken) {
@@ -34,7 +34,16 @@ export function getUserFromToken(tokenOverride) {
       return null;
     }
 
-    return decoded; // berisi: { id, email, role, iat, exp }
+    return {
+      id: decoded.sub ?? decoded.id ?? decoded.userId ?? null,
+      email: decoded.email ?? "",
+      role: decoded.role ?? "",
+      name: decoded.name ?? decoded.email ?? "",
+      avatar: decoded.avatar ?? "",
+      exp: decoded.exp,
+      iat: decoded.iat,
+      raw: decoded
+    };
   } catch (error) {
     console.error("Failed to decode token:", error);
     clearToken();

--- a/test-vite/src/main.jsx
+++ b/test-vite/src/main.jsx
@@ -77,7 +77,6 @@ const {
   FailureTable,
   BookingStatusTable,
 } = masterTables;
-import { getUserFromToken } from "./lib/utils/auth";
 
 
 

--- a/test-vite/src/pages/SearchCase_V3.jsx
+++ b/test-vite/src/pages/SearchCase_V3.jsx
@@ -29,6 +29,7 @@ import { format } from "date-fns";
 import { ComboboxDemo, SearchCommandBlock, SelectBarState } from "@/components/sc-select";
 import { toast } from "sonner";
 import { formatDateForInput,formatDate } from "@/lib/utils";
+import { useAuth } from "@/context/auth-context";
 
 /**
  * @fileoverview Create Case page (SearchCase_V3)
@@ -222,24 +223,6 @@ function classNames(...s) {
 }
 
 /**
- * Safely parse user id from JWT stored in localStorage under 'token'.
- * Returns null if token absent/invalid.
- * @returns {{id: any}|null}
- */
-function getUserFromTokenSafe() {
-  try {
-    const raw = localStorage.getItem("token");
-    if (!raw) return null;
-    const payload = JSON.parse(atob(raw.split(".")[1]));
-    return { id: payload?.id ?? payload?.userId,
-      user: payload
-     };
-  } catch {
-    return null;
-  }
-}
-
-/**
  * Utility object for formatting and parsing dates between UI and DB formats.
  */
 const DateHelper = {
@@ -277,6 +260,7 @@ const DateHelper = {
  */
 export default function NewCaseForm() {
   const navigate = useNavigate();
+  const { user } = useAuth();
 
   // Global state
   const [loading, setLoading] = useState(false);
@@ -1079,7 +1063,10 @@ export default function NewCaseForm() {
     
     setLoading(true);
     try {
-      const user = getUserFromTokenSafe();
+      if (!user) {
+        toast.error("User tidak valid. Silakan login kembali.");
+        return;
+      }
 
       const pickLabel = (value) => {
         if (value && typeof value === "object") {


### PR DESCRIPTION
## Summary
- add a dedicated refresh token model plus auth utilities, middleware and refresh/logout endpoints so the API can rotate short-lived access tokens and issue httpOnly cookies
- switch the React app to keep access tokens in memory, add automatic refresh handling in the auth context and axios client, and remove all token reads/writes from localStorage
- update gated UI (home call-to-action, sidebar profile/logout, master routes, audit windows, profile editor, etc.) to rely on the shared auth context and new session refresh helpers

## Testing
- `npm run lint` *(fails: repository eslint config references an invalid "no-unused-vars" setting)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d6a2cadac83329ff05b8d729b5bb4)